### PR TITLE
Update MinIO and mc to handle panfs path for buckets

### DIFF
--- a/api-bucket-panfs-path.go
+++ b/api-bucket-panfs-path.go
@@ -1,0 +1,64 @@
+/*
+ * MinIO Go Library for Amazon S3 Compatible Cloud Storage
+ * Copyright 2015-2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/minio/minio-go/v7/pkg/s3utils"
+)
+
+// GetBucketPanfsPath - get panfs path for the bucket name from the cache, if not
+// fetch freshly by making a new request.
+func (c *Client) GetBucketPanfsPath(ctx context.Context, bucketName string) (string, error) {
+	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
+		return "", err
+	}
+	return c.getBucketPanfsPath(ctx, bucketName)
+}
+
+// Request server for current bucket panfs path.
+func (c *Client) getBucketPanfsPath(ctx context.Context, bucketName string) (string, error) {
+	// Get resources properly escaped and lined up before
+	// using them in http request.
+	urlValues := make(url.Values)
+	urlValues.Set("panfs-path", "")
+
+	// Execute GET on bucket to list objects.
+	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
+		bucketName:       bucketName,
+		queryValues:      urlValues,
+		contentSHA256Hex: emptySHA256Hex,
+	})
+
+	defer closeResponse(resp)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract panfsPath.
+	var panfsPath string
+	err = xmlDecoder(resp.Body, &panfsPath)
+	if err != nil {
+
+		return "", err
+	}
+	return panfsPath, nil
+}

--- a/api-put-bucket.go
+++ b/api-put-bucket.go
@@ -33,16 +33,16 @@ func (c *Client) makeBucket(ctx context.Context, bucketName string, opts MakeBuc
 		return err
 	}
 
-	err = c.doMakeBucket(ctx, bucketName, opts.Region, opts.ObjectLocking)
+	err = c.doMakeBucket(ctx, bucketName, opts.Region, opts.PanfsPath, opts.ObjectLocking)
 	if err != nil && (opts.Region == "" || opts.Region == "us-east-1") {
 		if resp, ok := err.(ErrorResponse); ok && resp.Code == "AuthorizationHeaderMalformed" && resp.Region != "" {
-			err = c.doMakeBucket(ctx, bucketName, resp.Region, opts.ObjectLocking)
+			err = c.doMakeBucket(ctx, bucketName, resp.Region, opts.PanfsPath, opts.ObjectLocking)
 		}
 	}
 	return err
 }
 
-func (c *Client) doMakeBucket(ctx context.Context, bucketName string, location string, objectLockEnabled bool) (err error) {
+func (c *Client) doMakeBucket(ctx context.Context, bucketName string, location string, panfsPath string, objectLockEnabled bool) (err error) {
 	defer func() {
 		// Save the location into cache on a successful makeBucket response.
 		if err == nil {
@@ -68,6 +68,12 @@ func (c *Client) doMakeBucket(ctx context.Context, bucketName string, location s
 	if objectLockEnabled {
 		headers := make(http.Header)
 		headers.Add("x-amz-bucket-object-lock-enabled", "true")
+		reqMetadata.customHeader = headers
+	}
+
+	if panfsPath != "" {
+		headers := make(http.Header)
+		headers.Add("x-panfs-bucket-path", panfsPath)
 		reqMetadata.customHeader = headers
 	}
 
@@ -106,7 +112,8 @@ func (c *Client) doMakeBucket(ctx context.Context, bucketName string, location s
 // MakeBucketOptions holds all options to tweak bucket creation
 type MakeBucketOptions struct {
 	// Bucket location
-	Region string
+	Region    string
+	PanfsPath string
 	// Enable object locking
 	ObjectLocking bool
 }


### PR DESCRIPTION
This PR updates `mb` and `stat` commands allowing client to gather PanFS path and make bucket with additional metadata field.